### PR TITLE
Twofive: Adding the same pub extension as FB for TH to pass in FB appID

### DIFF
--- a/bid_request.go
+++ b/bid_request.go
@@ -246,7 +246,9 @@ type Publisher struct {
 }
 
 // PublisherExt ...
-type PublisherExt struct{}
+type PublisherExt struct {
+	FacebookAppID string `json:"facebook_app_id"  valid:"-"` // needed for pubs that have FB hybrid SDK solution in thier stack
+}
 
 // Content object describes the content in which the impression will appear, which may be syndicated or nonsyndicated
 // content. This object may be useful when syndicated content contains impressions and does


### PR DESCRIPTION
The new extension is to pass facebook app id.
The FB BidToken should be the 
Users.BuyerUID field