### PR TITLE
twofive: I need to make the TH user id more generic

### DIFF
--- a/bid_request.go
+++ b/bid_request.go
@@ -35,8 +35,8 @@ type Request struct {
 
 // RequestExt used to communicate the publishers api key
 type RequestExt struct {
-	ID     int    `json:"id" valid:"-"`
-	APIKey string `json:"api_key" valid:"uuidv4,required"`
+	APIKey    string `json:"api_key"    valid:"uuidv4,required"`
+	SessionID string `json:"session_id" valid:"required"`
 }
 
 // Source describes the nature and behavior of the entity that is the source of the bid request


### PR DESCRIPTION
This allows other pubs to pass the same information that TH pass as they
see fit, without the tie back to user_id. Also needed for TH local